### PR TITLE
Add workflows

### DIFF
--- a/.github/workflows/build-and-publish-image.yaml
+++ b/.github/workflows/build-and-publish-image.yaml
@@ -1,0 +1,33 @@
+name: build-and-publish-image
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  build-and-publish-image:
+    runs-on: ubuntu-20.04
+    permissions:
+      packages: write
+      contents: read
+    env:
+      VERSION: "1.0.0"
+
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image
+        run: docker image build
+          -t ghcr.io/acceptablesoftware/lex:$VERSION
+          ./lex
+
+      - name: Publish image
+        run: docker push ghcr.io/acceptablesoftware/lex:$VERSION

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,14 @@
+name: tests
+
+on: [push, pull_request]
+
+jobs:
+  test-image-builds:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+
+      - name: Build image
+        run: docker image build -t lex:build-test ./lex


### PR DESCRIPTION
This commit adds two workflows for building and publishing the Docker
image. The first workflow is `tests`, which is run on every push to
ensure the Docker image continues to build. The second workflow is
`build-and-publish-image` which only runs when something is merged into
the `master` branch. This builds the image and also publishes it to
GitHub packages.
